### PR TITLE
create a responsive navbar

### DIFF
--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -1,13 +1,46 @@
 import React, { Component } from 'react';
+import AppBar from "@material-ui/core/AppBar";
+import ToolBar from "@material-ui/core/ToolBar";
+import IconButton from "@material-ui/core/IconButton";
+import Typography from "@material-ui/core/Typography";
+import InputBase from "@material-ui/core/InputBase";
+import SearchIcon from "@material-ui/icons/Search";
+import Switch from "@material-ui/core/Switch";
+import { withStyles } from "@material-ui/core/styles";
+import styles from "./styles/NavBarStyles";
 
 class Navbar extends Component {
     render() {
+        const {classes} = this.props;
         return (
-            <div>
-                <h1>Navbar</h1>
+            <div className={classes.root}>
+                <AppBar position="static" color="primary">
+                    <ToolBar>
+                        <IconButton className={classes.menuButton} color="inherit">
+                            <span role="img">🎏</span>
+                        </IconButton>
+                        <Typography className={classes.title} varient="h6" color="inherit">
+                            App Title
+                        </Typography>
+                        <Switch />
+                        <div className={classes.grow} />
+                        <div className={classes.search}>
+                            <div className={classes.searchIcon}>
+                                <SearchIcon />
+                            </div>
+                            <InputBase 
+                                placeholder="Search..." 
+                                classes={{
+                                    root: classes.inputRoot,
+                                    input: classes.inputInput 
+                                }}
+                            />
+                        </div>
+                    </ToolBar>
+                </AppBar>
             </div>
         )
     }
 }
 
-export default Navbar;
+export default withStyles(styles)(Navbar);

--- a/src/styles/NavBarStyles.js
+++ b/src/styles/NavBarStyles.js
@@ -1,0 +1,63 @@
+import { fade } from "@material-ui/core/styles/colorManipulator";
+
+const styles = theme => ({
+    root: {
+        width: "100%",
+        marginBottom: 0
+    },
+    grow: {
+        flexGrow: 1
+    },
+    menuButton: {
+        marginLeft: -12,
+        marginRight: 20
+    },
+    title: {
+        display: "none",
+        [theme.breakpoints.up("sm")] : {
+            display: "block"
+        }
+    },
+    search: {
+        position: "relative",
+        borderRadius: theme.shape.borderRadius,
+        backgroundColor: fade(theme.palette.common.white, 0.15),
+        "&:hover": {
+            backgroundColor: fade(theme.palette.common.white, 0.25)
+        },
+        marginLeft: 0,
+        width: "100%",
+        [theme.breakpoints.up("sm")] : {
+            marginLeft: theme.spacing.unit,
+            width: "auto"
+        }
+    },
+    searchIcon: {
+        width: theme.spacing.unit * 9,
+        height: "100%",
+        position: "absolute",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center"
+    },
+    inputRoot: {
+        color: "inherit",
+        width: "100%"
+    },
+    inputInput: {
+        paddingTop: theme.spacing.unit,
+        paddingRight: theme.spacing.unit,
+        paddingBottom: theme.spacing.unit,
+        paddingLeft: theme.spacing.unit * 10,
+        transition: theme.transitions.create("width"),
+        width: "100%",
+        [theme.breakpoints.up("sm")]: {
+            width: 120,
+            "&:focus": {
+                width: 200
+            }
+        }
+    }
+});
+
+export default styles;


### PR DESCRIPTION
A navbar is created for this application.  The "material-ui" library is used to style the navbar, along with `{withStyles}`.

In `Navbar.js`, a number of items are imported from "material-ui".  Then an `AppBar` and a `ToolBar` are added in the component.  Also an `IconButton` is then added.   A `<span>` element is added, and for now, a simple flag emoji is added here.  A `Typography` element is also added, as well as a `Switch`.  Inside the `Switch` are several divs to be used for responsiveness for the nav bar.  The `SearchIcon` is also added here.

Next a new folder is added named `styles`.  Inside this folder, a new file is named `NavBarStyles.js`.  The styles are defined with a function named `theme`.  Then the classes are all individually styled.  The `root` class is given width and margin.  The `grow` class is given a flex property.  The `menuButton` class is given some margin.  The `title` class is set to display as none in smaller sizes, and at a breakpoint is displayed.  The `search` class is given a position, border radius, and background color that is set to fade slightly different when hovered over.  At the top of this component, `fade` is imported from "material-ui".  Also this class is given a margin and a width, which is changed on a breakpoint.  The `searchIcon` class is given width, height, position, and display properties.

In `NavBar.js` the `styles` folder is imported at the top.  At the bottom, this component is set to `export default withStyles(styles)(Navbar)`.  Then a variable is set where `{classes}` is set to `this.props`.  Also, a search text field is added by using `InputBase` from "material-ui". 
 
In `NavBarStyles`, the `InputBase` class is given a color and a color and a width.  In the `inputInput` class, it's given padding, transition, and width.  The width is set to be different at a breakpoint, and set to grow when it's focused on.

