### PR TITLE
a theme context is created with a provider set up

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,18 @@
 import React, { Component } from 'react';
 import Navbar from './Navbar';
 import Form from './Form';
+import PageContent from './PageContent';
+import {ThemeProvider} from './contexts/ThemeContext'
 
 class App extends Component {
   render() {
     return (
-      <>
-        < Navbar />
-        < Form />
-      </>
+      <ThemeProvider>
+        <PageContent>
+          < Navbar />
+          < Form />
+        </PageContent>
+      </ThemeProvider>
     );
   }
 }

--- a/src/PageContent.js
+++ b/src/PageContent.js
@@ -1,0 +1,15 @@
+import React, {Component} from 'react';
+
+export default class PageContent extends Component {
+    render() {
+        const styles = {
+            backgroundColor: "white",
+            height: "100vh",
+            width: "100vw"            
+        }
+
+        return (
+            <div style={styles}>{this.props.children}</div>
+        )
+    }
+}

--- a/src/contexts/ThemeContext.js
+++ b/src/contexts/ThemeContext.js
@@ -1,0 +1,17 @@
+import React, {Component, createContext} from 'react';
+
+export const ThemeContext = createContext();
+
+export class ThemeProvider extends Component {
+    constructor(props) {
+        super(props);
+        this.state = { isDarkMode: true };
+    }
+    render() {
+        return (
+            <ThemeContext.Provider value={{...this.state}}>
+                {this.props.children}
+            </ThemeContext.Provider>
+        )
+    }    
+}


### PR DESCRIPTION
First a component named `PageContent.js` is created.  A few css properties are set up right inside the component, which are background color, height, and width.  This component is then set to return a `div` with `{this.props.children}`, so it can be styled and applied to the descendents.

In `App.js`, that component is then set in the return to replace the fragment that is wrapped around the other components.

A `contexts` directory is created, with a `ThemeContext.js` file inside.  At the top, `React` is imported along with `createContext`.  Then `ThemeContext` is set as a variable to use `createContext()`.  A `ThemeProvider` component is then created inside this file.  This will return the `ThemeContext.Provider`, which contains `{this.props.children}`.  The `state` is set at the top, and state is initialized with a boolean of `isDarkMode` set to true.  Then the `value` property is passed into the `ThemeContext.Provider`, and the entire `state` is passed in here.  The necessary items are exported as well.  

In `App.js`, this `ThemeProvider` is also imported at the top.  Also, all of the content is wrapped inside `ThemeProvider`.