### PR TITLE
set components to consume theme context

### DIFF
--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -8,13 +8,16 @@ import SearchIcon from "@material-ui/icons/Search";
 import Switch from "@material-ui/core/Switch";
 import { withStyles } from "@material-ui/core/styles";
 import styles from "./styles/NavBarStyles";
+import {ThemeContext} from "./contexts/ThemeContext";
 
 class Navbar extends Component {
+    static contextType = ThemeContext;
     render() {
+        const { isDarkMode} = this.context;
         const {classes} = this.props;
         return (
             <div className={classes.root}>
-                <AppBar position="static" color="primary">
+                <AppBar position="static" color={ isDarkMode ? "default" : "primary" }>
                     <ToolBar>
                         <IconButton className={classes.menuButton} color="inherit">
                             <span role="img" aria-label="flag">🎏</span>

--- a/src/PageContent.js
+++ b/src/PageContent.js
@@ -1,9 +1,12 @@
 import React, {Component} from 'react';
+import {ThemeContext} from './contexts/ThemeContext';
 
 export default class PageContent extends Component {
+    static contextType = ThemeContext;
     render() {
+        const { isDarkMode } = this.context;
         const styles = {
-            backgroundColor: "white",
+            backgroundColor: isDarkMode ? "black" : "white",
             height: "100vh",
             width: "100vw"            
         }

--- a/src/contexts/ThemeContext.js
+++ b/src/contexts/ThemeContext.js
@@ -5,7 +5,7 @@ export const ThemeContext = createContext();
 export class ThemeProvider extends Component {
     constructor(props) {
         super(props);
-        this.state = { isDarkMode: true };
+        this.state = { isDarkMode: false };
     }
     render() {
         return (


### PR DESCRIPTION
This sets up the necessary components to consume the `ThemeContext`.  
In `Navbar.js`, the `ThemeContext` is imported at the top.  Then this component is set to look for the correct context with `static contextType = ThemeContext`.   To access the data, a variable is set to grab `isDarkMode` and this is set to be `this.context`.  Now in the `AppBar`, the color is set to instead look at `darkMode` and sets the color to "default" or "primary", depending on whether it's true or false.

A similar setup is done here.  In `PageContent.js`,  the `ThemeContext` is again imported at the top.  Also, the this component is again set to look for the correct context with `static contextType = ThemeContext`, and to access the data, a variable is set to grab `isDarkMode` and this is set to be `this.context`.  Now in the `styles`, the background color is set to instead look at `darkMode` and sets the color to "black" or "white", depending on whether it's true or false.

In `ThemeContext.js`, the initial state is set to be "false" by default.