### PR TITLE
add functionality to toggle theme context dynamically

### DIFF
--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -13,7 +13,7 @@ import {ThemeContext} from "./contexts/ThemeContext";
 class Navbar extends Component {
     static contextType = ThemeContext;
     render() {
-        const { isDarkMode} = this.context;
+        const { isDarkMode, toggleTheme } = this.context;
         const {classes} = this.props;
         return (
             <div className={classes.root}>
@@ -25,7 +25,7 @@ class Navbar extends Component {
                         <Typography className={classes.title} varient="h6" color="inherit">
                             App Title
                         </Typography>
-                        <Switch />
+                        <Switch onChange={toggleTheme} />
                         <div className={classes.grow} />
                         <div className={classes.search}>
                             <div className={classes.searchIcon}>

--- a/src/contexts/ThemeContext.js
+++ b/src/contexts/ThemeContext.js
@@ -6,10 +6,15 @@ export class ThemeProvider extends Component {
     constructor(props) {
         super(props);
         this.state = { isDarkMode: false };
+        this.toggleTheme = this.toggleTheme.bind(this);
+    }
+
+    toggleTheme() {
+        this.setState({ isDarkMode: !this.state.isDarkMode });
     }
     render() {
         return (
-            <ThemeContext.Provider value={{...this.state}}>
+            <ThemeContext.Provider value={{ ...this.state, toggleTheme: this.toggleTheme }}>
                 {this.props.children}
             </ThemeContext.Provider>
         )


### PR DESCRIPTION
This allows a user to use the toggle switch in the Nav bar to dynamically toggle the dark mode on/off, by using the Theme context.

In `ThemeContext.js`, a method is created called `toggleTheme`.  This changes the `state` to update `isDarkMode` between false and true.  This is then set in the constructor to `bind`.  Now, this method is then passed into the `value` of the Provider, and is named `toggleTheme`.

In `Navbar.js`, we grab `toggleTheme` from `this.context`, by adding it to the variable.  Then in the `<Switch>`, the `onChange` is set to `toggleTheme`, so that the method allows us to toggle dark mode.