### PR TITLE
adds a language context with with a provider

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,15 +3,18 @@ import Navbar from './Navbar';
 import Form from './Form';
 import PageContent from './PageContent';
 import {ThemeProvider} from './contexts/ThemeContext'
+import {LanguageProvider} from './contexts/LanguageContext';
 
 class App extends Component {
   render() {
     return (
       <ThemeProvider>
-        <PageContent>
-          < Navbar />
-          < Form />
-        </PageContent>
+        <LanguageProvider>
+          <PageContent>
+            < Navbar />
+            < Form />
+          </PageContent>
+        </LanguageProvider>
       </ThemeProvider>
     );
   }

--- a/src/contexts/LanguageContext.js
+++ b/src/contexts/LanguageContext.js
@@ -1,0 +1,18 @@
+import React, {Component, createContext} from 'react';
+
+export const LanguageContext = createContext();
+
+export class LanguageProvider extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {language: "french"};
+    }
+
+    render() {
+        return (
+            <LanguageContext.Provider value={ this.state.language }>
+                {this.props.children}
+            </LanguageContext.Provider>
+        )
+    }
+}


### PR DESCRIPTION
This adds another context, the Language context, and sets up the Provider for it as well.

Inside the `Contexts` folder, a file is created named `LanguageContext.js`.  The setup is similar to the `ThemeContext.js` file.  At the top, React is imported along with `createContext`. Then `LanguageContext` is set as a variable to use `createContext()`. A `LanguageProvider` component is then created inside this file. This will return the `LanguageContext.Provider`, which contains `{this.props.children}`. The state is set at the top, and state is initialized with "language" set to "french". Then the `value` property is passed into the `LanguageContext.Provider`, and the string from the state is passed in here, which is `this.state.language`. The necessary items are exported as well.

In App.js, this `LanguageProvider` is also imported at the top. Also, all of the content inside `ThemeProvider` is wrapped inside `LanguageProvider` in the render.