### PR TITLE
inline use to consume second context in navbar

### DIFF
--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -9,6 +9,7 @@ import Switch from "@material-ui/core/Switch";
 import { withStyles } from "@material-ui/core/styles";
 import styles from "./styles/NavBarStyles";
 import { ThemeContext } from "./contexts/ThemeContext";
+import { LanguageContext } from "./contexts/LanguageContext";
 
 class Navbar extends Component {
     static contextType = ThemeContext;
@@ -16,32 +17,36 @@ class Navbar extends Component {
         const { isDarkMode, toggleTheme } = this.context;
         const {classes} = this.props;
         return (
-            <div className={classes.root}>
-                <AppBar position="static" color={ isDarkMode ? "default" : "primary" }>
-                    <ToolBar>
-                        <IconButton className={classes.menuButton} color="inherit">
-                            <span role="img" aria-label="flag">🎏</span>
-                        </IconButton>
-                        <Typography className={classes.title} varient="h6" color="inherit">
-                            App Title
-                        </Typography>
-                        <Switch onChange={toggleTheme} />
-                        <div className={classes.grow} />
-                        <div className={classes.search}>
-                            <div className={classes.searchIcon}>
-                                <SearchIcon />
-                            </div>
-                            <InputBase 
-                                placeholder="Search..." 
-                                classes={{
-                                    root: classes.inputRoot,
-                                    input: classes.inputInput 
-                                }}
-                            />
-                        </div>
-                    </ToolBar>
-                </AppBar>
-            </div>
+            <LanguageContext.Consumer>
+                {content =>
+                    <div className={classes.root}>
+                        <AppBar position="static" color={ isDarkMode ? "default" : "primary" }>
+                            <ToolBar>
+                                <IconButton className={classes.menuButton} color="inherit">
+                                    <span role="img" aria-label="flag">🎏</span>
+                                </IconButton>
+                                <Typography className={classes.title} varient="h6" color="inherit">
+                                    App Title
+                                </Typography>
+                                <Switch onChange={toggleTheme} />
+                                <div className={classes.grow} />
+                                <div className={classes.search}>
+                                    <div className={classes.searchIcon}>
+                                        <SearchIcon />
+                                    </div>
+                                    <InputBase 
+                                        placeholder= {`${content.language}...`}
+                                        classes={{
+                                            root: classes.inputRoot,
+                                            input: classes.inputInput 
+                                        }}
+                                    />
+                                </div>
+                            </ToolBar>
+                        </AppBar>
+                    </div>
+                }
+            </LanguageContext.Consumer>
         )
     }
 }


### PR DESCRIPTION
This uses just one method of consuming the Language Context inside the Navbar Component.  This was only partially implemented to test out, but will be refactored to use a Higher Order Component.

Inside `Navbar.js`, the `LanguageContext` was imported from that Component.  Then inline, inside the `render`, the syntax `<LanguageContext.Consumer>` is used that accepts a function as a child.  The function accepts a value named `content`, and the entire rest of the Component is placed inside this function.  Then in the `InputBase` element, inside the `placeholder`, the "Search..." text is replaced with the value of the language coming from the Language Context.  This is done with `content.language`, that is interpolated with the "...".  

This is all that is done with this method, simply for testing purposes.  The Language Context is fully implemented by being refactored, as mentioned above, by next using a Higher Order Component.