### PR TITLE
navbar refactored to consume language higher order component

### DIFF
--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -9,46 +9,60 @@ import Switch from "@material-ui/core/Switch";
 import { withStyles } from "@material-ui/core/styles";
 import styles from "./styles/NavBarStyles";
 import { ThemeContext } from "./contexts/ThemeContext";
-import { LanguageContext } from "./contexts/LanguageContext";
+import { withLanguageContext } from "./contexts/LanguageContext";
+
+const content = {
+    english: {
+        search: "Search",
+        flag: <img alt="Flag of the United States of America" src="//upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/220px-Flag_of_the_United_States.svg.png" width="30" height="25" />
+    },
+    french: {
+        search: "Chercher",
+        // flag: "🇫🇷"
+        flag: <img alt="File:Flag of France" src="//upload.wikimedia.org/wikipedia/en/thumb/c/c3/Flag_of_France.svg/800px-Flag_of_France.svg.png" width="30" height="25"/>
+    },
+    spanish: {
+        search: "Buscar",
+        flag: <img alt="Flag of Spain (Civil)" src="//upload.wikimedia.org/wikipedia/commons/thumb/3/32/Flag_of_Spain_%28Civil%29.svg/200px-Flag_of_Spain_%28Civil%29.svg.png" width="30" height="25" />
+    }
+};
 
 class Navbar extends Component {
     static contextType = ThemeContext;
     render() {
         const { isDarkMode, toggleTheme } = this.context;
-        const {classes} = this.props;
+        const { classes } = this.props;
+        const { language } = this.props.languageContext;
+        const { search, flag } = content[language];
         return (
-            <LanguageContext.Consumer>
-                {content =>
-                    <div className={classes.root}>
-                        <AppBar position="static" color={ isDarkMode ? "default" : "primary" }>
-                            <ToolBar>
-                                <IconButton className={classes.menuButton} color="inherit">
-                                    <span role="img" aria-label="flag">🎏</span>
-                                </IconButton>
-                                <Typography className={classes.title} varient="h6" color="inherit">
-                                    App Title
-                                </Typography>
-                                <Switch onChange={toggleTheme} />
-                                <div className={classes.grow} />
-                                <div className={classes.search}>
-                                    <div className={classes.searchIcon}>
-                                        <SearchIcon />
-                                    </div>
-                                    <InputBase 
-                                        placeholder= {`${content.language}...`}
-                                        classes={{
-                                            root: classes.inputRoot,
-                                            input: classes.inputInput 
-                                        }}
-                                    />
-                                </div>
-                            </ToolBar>
-                        </AppBar>
-                    </div>
-                }
-            </LanguageContext.Consumer>
+            <div className={classes.root}>
+                <AppBar position="static" color={ isDarkMode ? "default" : "primary" }>
+                    <ToolBar>
+                        <IconButton className={classes.menuButton} color="inherit">
+                            <span role="img" aria-label="flag" style= {{marginTop: "7px"}}>{flag}</span>
+                        </IconButton>
+                        <Typography className={classes.title} varient="h6" color="inherit">
+                            App Title
+                        </Typography>
+                        <Switch onChange={toggleTheme} />
+                        <div className={classes.grow} />
+                        <div className={classes.search}>
+                            <div className={classes.searchIcon}>
+                                <SearchIcon />
+                            </div>
+                            <InputBase 
+                                placeholder= {`${search}...`}
+                                classes={{
+                                    root: classes.inputRoot,
+                                    input: classes.inputInput 
+                                }}
+                            />
+                        </div>
+                    </ToolBar>
+                </AppBar>
+            </div>
         )
     }
 }
 
-export default withStyles(styles)(Navbar);
+export default withLanguageContext(withStyles(styles)(Navbar));

--- a/src/contexts/LanguageContext.js
+++ b/src/contexts/LanguageContext.js
@@ -5,7 +5,7 @@ export const LanguageContext = createContext();
 export class LanguageProvider extends Component {
     constructor(props) {
         super(props);
-        this.state = {language: "spanish"};
+        this.state = {language: "english"};
         this.changeLanguage = this.changeLanguage.bind(this);
     }
 
@@ -21,3 +21,10 @@ export class LanguageProvider extends Component {
         )
     }
 }
+
+// Higher Order Component
+export const withLanguageContext = Component => props => (
+    <LanguageContext.Consumer>
+        {value => <Component languageContext={value} {...props} />}
+    </LanguageContext.Consumer>
+)


### PR DESCRIPTION
This was a refactor of the `Navbar.js` component, to instead have it consume the Language Context from a higher order component inside the `LanguageContext.js`. 

First in `Navbar.js`, the `<LanguageContext.Consumer>` element is removed from wrapping the items within the return, as well we the `content` function that goes with it.  Also, `LanguageContext` is no longer imported.  Now it all can be refactored.

In `LanguageContext.js`, first the default laguage in the state is set to "English".  Then at the bottom of this component, a higher order component is made.  It is set to a variable called `withLanguageContext`, that expects a component with some props.  It returns a `<LanguageContext.Consumer`>,  that takes a function as a child where the `value` returns a Component with a new prop named `LanguageContext` with a value set to `value`.  Also, all other props (`{...props}`) are added in as well.  The entire block of code is then set to `export`.  

In `Navbar.js`, the `withLanguageContext` is then imported.  Then we wrap the entire component at the bottom with `withLanguageContext`, which now gives us access to its props.  Then the `language` is extracted from `this.props.LanguageContext`.  Some new objects are added to a variable named `content`.  In each of these objects, the 3 languages each have their own "search" that is translated, as well as a "flag" image.  The variables of `search` and `flag` are then extracted as variables by setting them equal to `content` of `[Language]`.  Now, to use these, in the `<IconButton>` element, the `flag` variable is used.  Then in `<InputBase>`, the `placeholder` is set to interpolate the `search` variable, followed by "...". 

